### PR TITLE
Fix silent dry-run when model is missing or generation produces no audio

### DIFF
--- a/app/src/main/java/com/CodeBySonu/VoxSherpa/system/VoxSherpaTtsService.java
+++ b/app/src/main/java/com/CodeBySonu/VoxSherpa/system/VoxSherpaTtsService.java
@@ -149,9 +149,15 @@ public class VoxSherpaTtsService extends TextToSpeechService {
             String modelType = sp.getString("active_model_type", "");
             CharSequence charText = request.getCharSequenceText();
 
-            // 1a. Empty text is a legitimate empty utterance — emit a valid (silent) frame.
+            // 1a. Empty text — call start()+done() (no audio). The framework treats this
+            // as a successful zero-length utterance, which is the correct semantic for
+            // empty input. If start() itself fails, surface as error().
             if (charText == null || charText.toString().trim().isEmpty()) {
-                callback.start(22050, AudioFormat.ENCODING_PCM_16BIT, 1);
+                int startResult = callback.start(22050, AudioFormat.ENCODING_PCM_16BIT, 1);
+                if (startResult != TextToSpeech.SUCCESS) {
+                    callback.error();
+                    hasError = true;
+                }
                 return;
             }
 
@@ -282,7 +288,15 @@ public class VoxSherpaTtsService extends TextToSpeechService {
                 if (isSynthesisCancelled) break;
 
                 if (chunkPcm != null && chunkPcm.length > 0) {
-                    if (_streamAudioChunks(chunkPcm, callback)) {
+                    StreamResult result = _streamAudioChunks(chunkPcm, callback);
+                    if (result == StreamResult.PARTIAL_FAILURE) {
+                        // audioAvailable() rejected a chunk mid-stream. The utterance
+                        // is incomplete — surface as error rather than silent partial success.
+                        callback.error();
+                        hasError = true;
+                        return;
+                    }
+                    if (result == StreamResult.COMPLETE) {
                         emittedAudio = true;
                     }
                 }
@@ -307,11 +321,22 @@ public class VoxSherpaTtsService extends TextToSpeechService {
         }
     }
 
+    /** Outcome of streaming a single sentence's PCM to the framework. */
+    private enum StreamResult {
+        /** No audio was written (input was empty or first write was rejected). */
+        NO_AUDIO,
+        /** Some chunks streamed successfully, then a later audioAvailable() failed. */
+        PARTIAL_FAILURE,
+        /** All chunks delivered cleanly, or stopped because the caller cancelled. */
+        COMPLETE,
+    }
+
     // Dynamic Chunk Streaming logic mapped to OS Buffer Limits.
-    // Returns true if at least one PCM chunk was successfully delivered to the
-    // callback; callers use this to detect engine "dry runs" where audio was
-    // expected but never written.
-    private boolean _streamAudioChunks(byte[] pcm, SynthesisCallback callback) {
+    // Returns one of {NO_AUDIO, PARTIAL_FAILURE, COMPLETE} so the caller can
+    // distinguish a clean stream from a partial-failure (which must be surfaced
+    // as callback.error()) and from an empty/dry stream (which feeds the
+    // emittedAudio guard at the top level).
+    private StreamResult _streamAudioChunks(byte[] pcm, SynthesisCallback callback) {
         boolean wroteAny = false;
         try {
             int maxBufferSize = callback.getMaxBufferSize();
@@ -326,12 +351,13 @@ public class VoxSherpaTtsService extends TextToSpeechService {
                 int writeStatus = callback.audioAvailable(pcm, offset, end - offset);
 
                 if (writeStatus != TextToSpeech.SUCCESS) {
-                    break;
+                    return wroteAny ? StreamResult.PARTIAL_FAILURE : StreamResult.NO_AUDIO;
                 }
                 wroteAny = true;
             }
         } catch (Exception ignored) {
+            return wroteAny ? StreamResult.PARTIAL_FAILURE : StreamResult.NO_AUDIO;
         }
-        return wroteAny;
+        return wroteAny ? StreamResult.COMPLETE : StreamResult.NO_AUDIO;
     }
 }

--- a/app/src/main/java/com/CodeBySonu/VoxSherpa/system/VoxSherpaTtsService.java
+++ b/app/src/main/java/com/CodeBySonu/VoxSherpa/system/VoxSherpaTtsService.java
@@ -139,21 +139,30 @@ public class VoxSherpaTtsService extends TextToSpeechService {
     @Override
     protected void onSynthesizeText(SynthesisRequest request, SynthesisCallback callback) {
         isSynthesisCancelled = false;
-        boolean hasError = false; // The Fix: Track errors to avoid duplicate or conflicting callback triggers
-        
+        boolean hasError = false; // Track errors to avoid duplicate or conflicting callback triggers
+        boolean emittedAudio = false; // Track whether any PCM was actually streamed; if not, surface error()
+
         try {
             SharedPreferences sp = getSharedPreferences("sp1", MODE_PRIVATE);
             SharedPreferences sp3 = getSharedPreferences("sp3", MODE_PRIVATE);
-            
+
             String modelType = sp.getString("active_model_type", "");
             CharSequence charText = request.getCharSequenceText();
-            
-            // 1. Handle Empty Text Gracefully
-            if (modelType.isEmpty() || charText == null || charText.toString().trim().isEmpty()) {
-                // OS Rule: start() MUST be called before done().
-                // We call start with default format, then return so the finally block safely calls done().
+
+            // 1a. Empty text is a legitimate empty utterance — emit a valid (silent) frame.
+            if (charText == null || charText.toString().trim().isEmpty()) {
                 callback.start(22050, AudioFormat.ENCODING_PCM_16BIT, 1);
-                return; 
+                return;
+            }
+
+            // 1b. No model loaded → surface as error() instead of start()+done() with no audio.
+            // Without this, every synth call returns "successfully" but produces silence, which
+            // looks like dry-running to clients (they see onStart/onDone but hear nothing). Any
+            // client that watches for sub-real-time onStart cadence will detect a runaway here.
+            if (modelType.isEmpty()) {
+                callback.error();
+                hasError = true;
+                return;
             }
             
             String text = charText.toString().trim();
@@ -273,40 +282,56 @@ public class VoxSherpaTtsService extends TextToSpeechService {
                 if (isSynthesisCancelled) break;
 
                 if (chunkPcm != null && chunkPcm.length > 0) {
-                    _streamAudioChunks(chunkPcm, callback);
+                    if (_streamAudioChunks(chunkPcm, callback)) {
+                        emittedAudio = true;
+                    }
                 }
+            }
+
+            // If start() was called but the engine produced no PCM at all (model
+            // loaded but generation silently failed for every sentence), surface
+            // the failure to the client instead of returning success with silence.
+            if (!emittedAudio && !isSynthesisCancelled) {
+                callback.error();
+                hasError = true;
             }
 
         } catch (Exception e) {
             callback.error();
             hasError = true;
         } finally {
-            // The Fix: Guarantees done() is only called if error() was NOT called.
+            // Guarantees done() is only called if error() was NOT called.
             if (!hasError) {
                 callback.done();
             }
         }
     }
 
-    // Dynamic Chunk Streaming logic mapped to OS Buffer Limits
-    private void _streamAudioChunks(byte[] pcm, SynthesisCallback callback) {
+    // Dynamic Chunk Streaming logic mapped to OS Buffer Limits.
+    // Returns true if at least one PCM chunk was successfully delivered to the
+    // callback; callers use this to detect engine "dry runs" where audio was
+    // expected but never written.
+    private boolean _streamAudioChunks(byte[] pcm, SynthesisCallback callback) {
+        boolean wroteAny = false;
         try {
             int maxBufferSize = callback.getMaxBufferSize();
-            int chunkSize = (maxBufferSize > 0) ? maxBufferSize : 8192; 
+            int chunkSize = (maxBufferSize > 0) ? maxBufferSize : 8192;
 
             for (int offset = 0; offset < pcm.length; offset += chunkSize) {
                 if (isSynthesisCancelled) {
                     break;
                 }
-                
+
                 int end = Math.min(offset + chunkSize, pcm.length);
                 int writeStatus = callback.audioAvailable(pcm, offset, end - offset);
-                
+
                 if (writeStatus != TextToSpeech.SUCCESS) {
-                    break; 
+                    break;
                 }
+                wroteAny = true;
             }
         } catch (Exception ignored) {
         }
+        return wroteAny;
     }
 }


### PR DESCRIPTION
## What's broken

`VoxSherpaTtsService.onSynthesizeText()` has two paths that fire `callback.start()` followed by `callback.done()` **without ever calling `callback.audioAvailable()`**. From Android's `TextToSpeechService` framework perspective, this looks like a successfully-spoken empty utterance — the framework dispatches `UtteranceProgressListener.onStart` and `onDone` to clients in milliseconds, and clients think speech worked. But no audio plays.

This is the underlying cause of \"speed-running\" / dry-run reports in clients — the position bar advances at engine-callback rate (effectively unbounded) instead of audio-playback rate, and the user hears nothing.

### The two paths

1. **`active_model_type` is empty in SharedPreferences** (e.g. on first install before the user has picked a voice/model in VoxSherpa). Previously bundled with the \"empty text\" early-return, which calls `start()` + falls through to `finally { done(); }`.

2. **Model is loaded but `generateAudioPCM(...)` returns `null` or zero-length** for every sentence. The for-loop completes silently and `finally { done(); }` reports success.

## Fix

- Split the early-return: empty text remains a legitimate empty utterance (emits a valid silent frame); **\"no model\"** is reclassified as `callback.error()`.
- Track whether `_streamAudioChunks()` ever delivered any PCM. If `start()` was called but no chunk was written, fire `callback.error()` instead of `callback.done()`.
- Refactor `_streamAudioChunks` to return `boolean` so the caller can detect the no-audio case.

Empty/whitespace text behaviour is unchanged.

## Why it matters

Without this, any client of the engine has to add their own \"sub-real-time onStart cadence\" detector and a recovery path, which is what storyvox ended up doing. The right place to surface \"I couldn't actually speak\" is `callback.error()`.

## Verification

Built locally and observed:
- With `active_model_type=\"\"`: synth calls now return error to the client (was: silent success)
- With model loaded: normal speech unchanged
- Empty text: still emits a clean empty utterance (no behavioural change)